### PR TITLE
feat: add rate-limit retry logic and partial result handling 

### DIFF
--- a/oasis-agent/lib/retry.test.ts
+++ b/oasis-agent/lib/retry.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getErrorStatus,
+  getRetryAfterHeader,
+  isRetryableStatus,
+  getRetryDelayMs,
+  withRateLimitRetry,
+  RATE_LIMIT_MAX_RETRIES,
+} from './retry.js';
+
+describe('getErrorStatus', () => {
+  it('extracts status from error.status', () => {
+    expect(getErrorStatus({ status: 429 })).toBe(429);
+    expect(getErrorStatus({ status: 400 })).toBe(400);
+  });
+
+  it('extracts status from error.statusCode', () => {
+    expect(getErrorStatus({ statusCode: 503 })).toBe(503);
+  });
+
+  it('extracts status from error.response.status', () => {
+    expect(getErrorStatus({ response: { status: 500 } })).toBe(500);
+  });
+
+  it('returns undefined for unknown error shape', () => {
+    expect(getErrorStatus(new Error('foo'))).toBeUndefined();
+    expect(getErrorStatus({})).toBeUndefined();
+  });
+});
+
+describe('getRetryAfterHeader', () => {
+  it('extracts retry-after from Headers-like object with get()', () => {
+    const headers = { get: (name: string) => (name === 'retry-after' ? '5' : null) };
+    expect(getRetryAfterHeader({ headers })).toBe('5');
+  });
+
+  it('extracts retry-after from Record', () => {
+    expect(getRetryAfterHeader({ headers: { 'retry-after': '10' } })).toBe('10');
+    expect(getRetryAfterHeader({ headers: { 'Retry-After': '15' } })).toBe('15');
+  });
+
+  it('extracts from response.headers', () => {
+    expect(getRetryAfterHeader({ response: { headers: { 'retry-after': '3' } } })).toBe('3');
+  });
+
+  it('returns undefined when no header', () => {
+    expect(getRetryAfterHeader({})).toBeUndefined();
+    expect(getRetryAfterHeader({ headers: {} })).toBeUndefined();
+  });
+});
+
+describe('isRetryableStatus', () => {
+  it('returns true for 429', () => {
+    expect(isRetryableStatus(429)).toBe(true);
+  });
+
+  it('returns true for 5xx', () => {
+    expect(isRetryableStatus(500)).toBe(true);
+    expect(isRetryableStatus(502)).toBe(true);
+    expect(isRetryableStatus(503)).toBe(true);
+    expect(isRetryableStatus(599)).toBe(true);
+  });
+
+  it('returns false for 4xx (except 429)', () => {
+    expect(isRetryableStatus(400)).toBe(false);
+    expect(isRetryableStatus(404)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isRetryableStatus(undefined)).toBe(false);
+  });
+});
+
+describe('getRetryDelayMs', () => {
+  it('uses Retry-After header when present and valid', () => {
+    expect(getRetryDelayMs(0, { headers: { 'retry-after': '5' } })).toBe(5000);
+    expect(getRetryDelayMs(1, { headers: { 'retry-after': '3' } })).toBe(3000);
+  });
+
+  it('caps Retry-After at 60s', () => {
+    expect(getRetryDelayMs(0, { headers: { 'retry-after': '90' } })).toBe(60000);
+  });
+
+  it('falls back to exponential backoff when no header', () => {
+    expect(getRetryDelayMs(0, {})).toBe(2000);
+    expect(getRetryDelayMs(1, {})).toBe(4000);
+    expect(getRetryDelayMs(2, {})).toBe(8000);
+  });
+
+  it('ignores invalid Retry-After', () => {
+    expect(getRetryDelayMs(0, { headers: { 'retry-after': 'invalid' } })).toBe(2000);
+  });
+});
+
+describe('withRateLimitRetry', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns result on first success', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+    const result = await withRateLimitRetry(fn, 'test');
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 429 and eventually succeeds', async () => {
+    const err429 = new Error('Rate limit') as Error & { status: number };
+    err429.status = 429;
+    const fn = vi.fn()
+      .mockRejectedValueOnce(err429)
+      .mockRejectedValueOnce(err429)
+      .mockResolvedValue('ok');
+    const resultPromise = withRateLimitRetry(fn, 'test');
+    await vi.advanceTimersByTimeAsync(2000); // First retry delay
+    await vi.advanceTimersByTimeAsync(4000); // Second retry delay
+    const result = await resultPromise;
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries on 429 up to max then throws', async () => {
+    const err429 = new Error('Rate limit') as Error & { status: number };
+    err429.status = 429;
+    const fn = vi.fn().mockRejectedValue(err429);
+    const resultPromise = withRateLimitRetry(fn, 'test');
+    // Advance timers and await rejection in same tick to avoid unhandled rejection
+    const [thrown] = await Promise.all([
+      resultPromise.then(() => null, (e: unknown) => e),
+      vi.advanceTimersByTimeAsync(14000),
+    ]);
+    expect(thrown).toMatchObject({ message: 'Rate limit', status: 429 });
+    expect(fn).toHaveBeenCalledTimes(RATE_LIMIT_MAX_RETRIES + 1);
+  });
+
+  it('does not retry on 400', async () => {
+    const err400 = new Error('Bad request') as Error & { status: number };
+    err400.status = 400;
+    const fn = vi.fn().mockRejectedValue(err400);
+    await expect(withRateLimitRetry(fn, 'test')).rejects.toThrow('Bad request');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on 503', async () => {
+    const err503 = new Error('Service unavailable') as Error & { status: number };
+    err503.status = 503;
+    const fn = vi.fn()
+      .mockRejectedValueOnce(err503)
+      .mockResolvedValue('ok');
+    const resultPromise = withRateLimitRetry(fn, 'test');
+    await vi.advanceTimersByTimeAsync(2000);
+    const result = await resultPromise;
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/oasis-agent/lib/retry.ts
+++ b/oasis-agent/lib/retry.ts
@@ -1,0 +1,70 @@
+/**
+ * Rate limit retry utilities: 429/5xx handling with exponential backoff and Retry-After support.
+ */
+
+import chalk from 'chalk';
+
+export const RATE_LIMIT_MAX_RETRIES = 3;
+export const RATE_LIMIT_BASE_DELAY_MS = 2000;
+
+export function getErrorStatus(error: unknown): number | undefined {
+  const err = error as { status?: number; statusCode?: number; response?: { status?: number } };
+  return err?.status ?? err?.statusCode ?? err?.response?.status;
+}
+
+export function getRetryAfterHeader(error: unknown): string | undefined {
+  const err = error as {
+    headers?: Headers | Record<string, string>;
+    response?: { headers?: Headers | Record<string, string> };
+  };
+  const headers = err?.headers ?? err?.response?.headers;
+  if (!headers) return undefined;
+  if (typeof (headers as Headers).get === 'function') {
+    return (headers as Headers).get?.('retry-after') ?? undefined;
+  }
+  return (headers as Record<string, string>)?.['retry-after'] ?? (headers as Record<string, string>)?.['Retry-After'];
+}
+
+export function isRetryableStatus(status: number | undefined): boolean {
+  return status === 429 || (status != null && status >= 500 && status < 600);
+}
+
+export function getRetryDelayMs(attempt: number, error: unknown): number {
+  const retryAfter = getRetryAfterHeader(error);
+  if (retryAfter) {
+    const seconds = parseInt(retryAfter, 10);
+    if (!isNaN(seconds) && seconds > 0) {
+      return Math.min(seconds * 1000, 60000); // Cap at 60s per spec
+    }
+  }
+  return RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt);
+}
+
+export async function withRateLimitRetry<T>(
+  fn: () => Promise<T>,
+  context: string
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      const status = getErrorStatus(error);
+      const isRetryable = isRetryableStatus(status);
+      const hasAttemptsLeft = attempt < RATE_LIMIT_MAX_RETRIES;
+
+      if (!isRetryable || !hasAttemptsLeft) {
+        throw error;
+      }
+
+      const delayMs = getRetryDelayMs(attempt, error);
+      console.log(chalk.yellow(
+        `[Rate limit] ${context}: ${status} on attempt ${attempt + 1}/${RATE_LIMIT_MAX_RETRIES + 1}. ` +
+        `Retrying in ${delayMs / 1000}s...`
+      ));
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+  }
+  throw lastError;
+}

--- a/oasis-agent/package.json
+++ b/oasis-agent/package.json
@@ -6,7 +6,9 @@
     "start": "tsx run.ts",
     "claude": "tsx run.ts --model claude",
     "grok": "tsx run.ts --model grok",
-    "analyze": "tsx analyze.ts"
+    "analyze": "tsx analyze.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.2",
@@ -17,6 +19,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "tsx": "^4.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^2.0.0"
   }
 }

--- a/oasis-agent/run.ts
+++ b/oasis-agent/run.ts
@@ -27,61 +27,11 @@ const FLAG_PATTERN = /KX\{[a-f0-9]+\}/i;
 const RESULTS_DIR = resolve(import.meta.dirname, '../results');
 const CHALLENGES_DIR = resolve(import.meta.dirname, '../challenges');
 
-// Rate limit retry: 3 attempts, exponential backoff (2s, 4s, 8s), respect Retry-After header
-const RATE_LIMIT_MAX_RETRIES = 3;
-const RATE_LIMIT_BASE_DELAY_MS = 2000;
-
-function isRetryableStatus(status: number | undefined): boolean {
-  return status === 429 || (status != null && status >= 500 && status < 600);
-}
-
-function getRetryDelayMs(attempt: number, error: unknown): number {
-  // Prefer Retry-After header if present and reasonable (<= 60s per spec)
-  const err = error as { headers?: Headers | Record<string, string>; response?: { headers?: Headers | Record<string, string> } };
-  const headers = err?.headers ?? err?.response?.headers;
-  if (headers) {
-    const retryAfter = typeof headers.get === 'function'
-      ? headers.get?.('retry-after')
-      : (headers as Record<string, string>)?.['retry-after'];
-    if (retryAfter) {
-      const seconds = parseInt(retryAfter, 10);
-      if (!isNaN(seconds) && seconds > 0 && seconds <= 60) {
-        return seconds * 1000;
-      }
-    }
-  }
-  // Exponential backoff: 2s, 4s, 8s
-  return RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt);
-}
-
-async function withRateLimitRetry<T>(
-  fn: () => Promise<T>,
-  context: string
-): Promise<T> {
-  let lastError: unknown;
-  for (let attempt = 0; attempt <= RATE_LIMIT_MAX_RETRIES; attempt++) {
-    try {
-      return await fn();
-    } catch (error) {
-      lastError = error;
-      const status = (error as { status?: number; statusCode?: number })?.status ?? (error as { status?: number; statusCode?: number })?.statusCode;
-      const isRetryable = isRetryableStatus(status);
-      const hasAttemptsLeft = attempt < RATE_LIMIT_MAX_RETRIES;
-
-      if (!isRetryable || !hasAttemptsLeft) {
-        throw error;
-      }
-
-      const delayMs = getRetryDelayMs(attempt, error);
-      console.log(chalk.yellow(
-        `[Rate limit] ${context}: ${status} on attempt ${attempt + 1}/${RATE_LIMIT_MAX_RETRIES + 1}. ` +
-        `Retrying in ${delayMs / 1000}s...`
-      ));
-      await new Promise(resolve => setTimeout(resolve, delayMs));
-    }
-  }
-  throw lastError;
-}
+import {
+  withRateLimitRetry,
+  RATE_LIMIT_MAX_RETRIES,
+  getErrorStatus,
+} from './lib/retry.js';
 
 // Challenge configuration loaded from challenge.json
 interface ChallengeConfig {
@@ -305,6 +255,57 @@ function saveAnalysis(runId: string, analysis: AnalysisResult): void {
   console.log(chalk.gray(`Analysis report saved to: ${reportPath}`));
 }
 
+/** Build partial RunResult for error reporting — single source of truth for all failure paths. */
+function buildPartialResult(opts: {
+  error: unknown;
+  runId?: string;
+  startTime?: Date;
+  endTime?: Date;
+  steps?: Step[];
+  tokens?: TokenUsage;
+  iterations?: number;
+  status?: number;
+  /** Override computed error message (e.g. for main() catch where error is generic) */
+  errorMessage?: string;
+}): RunResult {
+  const runId = opts.runId ?? agentConfig.runId ?? randomUUID().slice(0, 8);
+  const endTime = opts.endTime ?? new Date();
+  const startTime = opts.startTime ?? endTime; // Use same timestamp when unknown — honest over wrong
+  const steps = opts.steps ?? [];
+  const tokens = opts.tokens ?? { input: 0, output: 0, total: 0 };
+  const iterations = opts.iterations ?? 0;
+  const status = opts.status ?? getErrorStatus(opts.error);
+  const errMsg = opts.error instanceof Error ? opts.error.message : String(opts.error);
+
+  const commands = steps.filter(s => s.command).map(s => s.command!);
+  const stepTechniques = steps.map(s => s.technique || null);
+
+  const errorMessage = opts.errorMessage ?? (status === 429
+    ? `Rate limit (429) exceeded after ${RATE_LIMIT_MAX_RETRIES + 1} retries`
+    : `API error: ${errMsg}`);
+
+  return {
+    id: runId,
+    model: agentConfig.provider,
+    modelVersion: agentConfig.modelId,
+    challenge: challengeConfig.id,
+    startTime,
+    endTime,
+    success: false,
+    flag: null,
+    error: errorMessage,
+    totalTime: startTime !== endTime ? (endTime.getTime() - startTime.getTime()) / 1000 : 0,
+    iterations,
+    tokens,
+    steps,
+    techniquesUsed: getUniqueTechniques(commands),
+    tacticBreakdown: calculateTacticBreakdown(stepTechniques),
+    methodologies: [...new Set(steps.filter(s => s.methodology).map(s => s.methodology!))],
+    toolsUsed: [...new Set(steps.filter(s => s.tool).map(s => s.tool!))],
+    methodologyBreakdown: calculateMethodologyBreakdown(steps),
+  };
+}
+
 // Calculate methodology breakdown
 function calculateMethodologyBreakdown(steps: Step[]): Record<string, { count: number; percentage: number }> {
   const counts: Record<string, number> = {};
@@ -369,35 +370,19 @@ async function runClaudeAgent(): Promise<RunResult> {
         `Iteration ${iterations}`
       );
     } catch (error) {
-      const status = (error as { status?: number })?.status;
+      const status = getErrorStatus(error);
       const errMsg = error instanceof Error ? error.message : String(error);
       console.error(chalk.red(`\nAPI error after retries (status ${status ?? 'unknown'}): ${errMsg}`));
-      const endTime = new Date();
-      const totalTime = (endTime.getTime() - startTime.getTime()) / 1000;
-      const commands = steps.filter(s => s.command).map(s => s.command!);
-      const stepTechniques = steps.map(s => s.technique || null);
-      return {
-        id: runId,
-        model: agentConfig.provider,
-        modelVersion: agentConfig.modelId,
-        challenge: challengeConfig.id,
+      return buildPartialResult({
+        error,
+        runId,
         startTime,
-        endTime,
-        success: false,
-        flag: null,
-        error: status === 429
-          ? `Rate limit (429) exceeded after ${RATE_LIMIT_MAX_RETRIES + 1} retries`
-          : `API error: ${errMsg}`,
-        totalTime,
-        iterations,
-        tokens: totalTokens,
+        endTime: new Date(),
         steps,
-        techniquesUsed: getUniqueTechniques(commands),
-        tacticBreakdown: calculateTacticBreakdown(stepTechniques),
-        methodologies: [...new Set(steps.filter(s => s.methodology).map(s => s.methodology!))],
-        toolsUsed: [...new Set(steps.filter(s => s.tool).map(s => s.tool!))],
-        methodologyBreakdown: calculateMethodologyBreakdown(steps),
-      };
+        tokens: totalTokens,
+        iterations,
+        status,
+      });
     }
 
     // Track tokens for this response
@@ -629,35 +614,19 @@ async function runOpenAICompatibleAgent(): Promise<RunResult> {
         `Iteration ${iterations}`
       );
     } catch (error) {
-      const status = (error as { status?: number })?.status;
+      const status = getErrorStatus(error);
       const errMsg = error instanceof Error ? error.message : String(error);
       console.error(chalk.red(`\nAPI error after retries (status ${status ?? 'unknown'}): ${errMsg}`));
-      const endTime = new Date();
-      const totalTime = (endTime.getTime() - startTime.getTime()) / 1000;
-      const commands = steps.filter(s => s.command).map(s => s.command!);
-      const stepTechniques = steps.map(s => s.technique || null);
-      return {
-        id: runId,
-        model: agentConfig.provider,
-        modelVersion: agentConfig.modelId,
-        challenge: challengeConfig.id,
+      return buildPartialResult({
+        error,
+        runId,
         startTime,
-        endTime,
-        success: false,
-        flag: null,
-        error: status === 429
-          ? `Rate limit (429) exceeded after ${RATE_LIMIT_MAX_RETRIES + 1} retries`
-          : `API error: ${errMsg}`,
-        totalTime,
-        iterations,
-        tokens: totalTokens,
+        endTime: new Date(),
         steps,
-        techniquesUsed: getUniqueTechniques(commands),
-        tacticBreakdown: calculateTacticBreakdown(stepTechniques),
-        methodologies: [...new Set(steps.filter(s => s.methodology).map(s => s.methodology!))],
-        toolsUsed: [...new Set(steps.filter(s => s.tool).map(s => s.tool!))],
-        methodologyBreakdown: calculateMethodologyBreakdown(steps),
-      };
+        tokens: totalTokens,
+        iterations,
+        status,
+      });
     }
 
     // Track tokens
@@ -840,29 +809,12 @@ async function main() {
     console.error(chalk.red('Error:'), error);
     // Save minimal partial result so middleware gets proper error reporting instead of "no result file"
     try {
-      const runId = agentConfig.runId || randomUUID().slice(0, 8);
-      const endTime = new Date();
       const errMsg = error instanceof Error ? error.message : String(error);
-      const partialResult: RunResult = {
-        id: runId,
-        model: agentConfig.provider,
-        modelVersion: agentConfig.modelId,
-        challenge: challengeConfig.id,
-        startTime: new Date(), // Approximate - we don't have precise start
-        endTime,
-        success: false,
-        flag: null,
-        error: errMsg,
-        totalTime: 0,
-        iterations: 0,
-        tokens: { input: 0, output: 0, total: 0 },
-        steps: [],
-        techniquesUsed: [],
-        tacticBreakdown: {},
-        methodologies: [],
-        toolsUsed: [],
-        methodologyBreakdown: {},
-      };
+      const partialResult = buildPartialResult({
+        error,
+        errorMessage: errMsg,
+        endTime: new Date(),
+      });
       saveResults(partialResult);
       console.log(chalk.gray('Partial result saved for error reporting.'));
     } catch (saveErr) {

--- a/oasis-agent/vitest.config.ts
+++ b/oasis-agent/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});


### PR DESCRIPTION
### Summary

Adds robust rate-limit retry handling and ensures partial results are always saved
on failure for OpenAI-compatible and Claude agents.

---

### 1. Retry Helper: withRateLimitRetry

- Retries up to 4 total attempts (1 initial + 3 retries)
- Retries on:
  - HTTP 429 (rate limit)
  - HTTP 5xx (server errors)
- Exponential backoff:
  - 2s → 4s → 8s (2^attempt seconds)
- Uses `Retry-After` header when present and ≤ 60s
- Logs each retry attempt for observability

---

### 2. OpenAI-Compatible Agent

- Wrapped all `client.chat.completions.create()` calls with `withRateLimitRetry`
- On final failure after retries:
  - Builds a partial `RunResult`
  - Includes collected steps, tokens, iterations
  - Sets `error` with failure reason
  - Returns partial result instead of throwing
- Result is persisted via existing `saveResults()` in `main()`

---

### 3. Claude Agent

- Applied identical retry + partial-result handling
- Wrapped `client.messages.create()` with `withRateLimitRetry`
- Returns structured partial result on final failure

---

### 4. Improved main() Error Handling

- On unexpected errors:
  - Builds minimal `RunResult`
    - `success: false`
    - `agentConfig.runId`
    - `error` message
  - Calls `saveResults()` before `process.exit(1)`
- Prevents "Agent did not produce result file" middleware failures
- Ensures result file is always written

---

### 5. Type Changes

- Added optional `error?: string` to `RunResult`
  - Enables structured failure reporting

---

### Result

- More resilient API calls under rate limiting
- Graceful degradation instead of crashes
- Guaranteed result file output for middleware consumption
- Improved observability and debugging