### PR TITLE
Fix runtime limits & analyzer reliability

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -211,6 +211,7 @@ export const runCommand = new Command('run')
         } catch (analysisError) {
           spinnerAnalysis.fail('Analysis failed');
           console.error(colors.red(`  ${analysisError instanceof Error ? analysisError.message : 'Unknown error'}`));
+          console.log(colors.gray(`  Retry later with: oasis analyze ${result.id}`));
         }
       } else {
         // No analysis, just print basic stats

--- a/src/lib/analyzer.ts
+++ b/src/lib/analyzer.ts
@@ -17,6 +17,7 @@ import {
   calculateMaxPossibleScore,
   finalizeRubricScore,
 } from './scoring.js';
+import { withRateLimitRetry } from './retry.js';
 
 // =============================================================================
 // Configuration
@@ -424,12 +425,15 @@ export async function analyzeRun(
   const challengeTarget = options.challengeTarget || `Challenge: ${result.challenge}`;
   const prompt = buildAnalysisPrompt(result, challengeTarget, options.challengeConfig);
 
-  const response = await client.messages.create({
-    model: analyzerModel,
-    max_tokens: 4096,
-    system: SYSTEM_PROMPT,
-    messages: [{ role: 'user', content: prompt }],
-  });
+  const response = await withRateLimitRetry(
+    () => client.messages.create({
+      model: analyzerModel,
+      max_tokens: 4096,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+    'Analysis',
+  );
 
   const textContent = response.content.find(c => c.type === 'text');
   if (!textContent || textContent.type !== 'text') {

--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -113,6 +113,7 @@ async function runClaudeAgent(config: RunnerConfig): Promise<RunResult> {
 
   const runId = randomUUID().slice(0, 8);
   const maxIterations = config.maxIterations || config.challenge.limits?.maxIterations || 50;
+  const maxTimeSeconds = config.challenge.limits?.maxTimeSeconds;
   const startTime = new Date();
   let lastStepTime = startTime;
   const steps: Step[] = [];
@@ -153,6 +154,15 @@ async function runClaudeAgent(config: RunnerConfig): Promise<RunResult> {
   try {
     while (iterations < maxIterations && !foundFlag) {
       iterations++;
+
+      if (maxTimeSeconds) {
+        const elapsed = (Date.now() - startTime.getTime()) / 1000;
+        if (elapsed >= maxTimeSeconds) {
+          agentError = `Time limit exceeded (${elapsed.toFixed(1)}s / ${maxTimeSeconds}s max)`;
+          break;
+        }
+      }
+
       config.onProgress?.(`Agent iteration ${iterations}/${maxIterations}...`);
 
       if (config.verbose) {
@@ -311,6 +321,7 @@ async function runOpenAIAgent(config: RunnerConfig): Promise<RunResult> {
 
   const runId = randomUUID().slice(0, 8);
   const maxIterations = config.maxIterations || config.challenge.limits?.maxIterations || 50;
+  const maxTimeSeconds = config.challenge.limits?.maxTimeSeconds;
   const startTime = new Date();
   let lastStepTime = startTime;
   const steps: Step[] = [];
@@ -355,6 +366,15 @@ async function runOpenAIAgent(config: RunnerConfig): Promise<RunResult> {
   try {
     while (iterations < maxIterations && !foundFlag) {
       iterations++;
+
+      if (maxTimeSeconds) {
+        const elapsed = (Date.now() - startTime.getTime()) / 1000;
+        if (elapsed >= maxTimeSeconds) {
+          agentError = `Time limit exceeded (${elapsed.toFixed(1)}s / ${maxTimeSeconds}s max)`;
+          break;
+        }
+      }
+
       config.onProgress?.(`Agent iteration ${iterations}/${maxIterations}...`);
 
       if (config.verbose) {


### PR DESCRIPTION
## Summary

- Enforce `maxTimeSeconds` in both Claude and OpenAI agent loops
- Wrap analyzer API call with `withRateLimitRetry` for automatic retry on 429/5xx
- Add recovery hint (`oasis analyze <run-id>`) when post-run analysis fails

## Failure Scenarios

### 1. Runaway benchmark — time limit never enforced
A challenge config sets `"maxTimeSeconds": 600` but the agent ran for **2646 seconds** (44 min). The while loops only checked `iterations < maxIterations && !foundFlag` — if each iteration was slow (long API calls, long commands), the agent blew past the time limit while still under the iteration count. Now, elapsed time is checked at the top of every iteration before the next API call, and the loop breaks with a descriptive error in the result JSON.

### 2. Analysis crashes on rate limit — no retry
After a long benchmark run (many API calls eating into the rate limit), the post-run `analyzeRun()` hits a 429 from Anthropic. Unlike the runner which uses `withRateLimitRetry()`, the analyzer called `client.messages.create()` directly — a single 429 killed the entire analysis. Now the analyzer uses the same retry wrapper (3 retries, exponential backoff: 2s, 4s, 8s).

### 3. Analysis fails with no recovery path
When analysis fails for any reason (rate limit exhausted after retries, invalid key, network error), the catch block printed the error and moved on. The user had no idea the run data was already saved and they could re-run analysis without re-running the entire benchmark. Now it prints `Retry later with: oasis analyze <run-id>` so the user knows exactly how to recover.

## Test plan
- [x] `npm run build` — compiles cleanly
- [x] `npm test` — all 153 tests pass
- [ ] Run a challenge with a low `maxTimeSeconds` — agent should stop at the limit
- [ ] Trigger analysis after heavy rate-limit usage — should retry automatically
- [ ] Trigger an analysis failure — should see gray retry hint below the error