### PR TITLE
feat: multi-provider analyzer with quota-exceeded fail-fast

### DIFF
--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -3,10 +3,11 @@ import ora from 'ora';
 import { resolve as pathResolve } from 'path';
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { colors, status } from '../lib/display.js';
-import { getApiKey, getConfigValue, getChallengesDir, getResultsDir } from '../lib/config.js';
+import { getApiKey, getConfigValue, normalizeProvider, getEffectiveProviderUrl, getChallengesDir, getResultsDir } from '../lib/config.js';
 import { analyzeRun } from '../lib/analyzer.js';
 import { saveAnalysisResult } from '../lib/runner.js';
 import { printAnalysisSummary } from '../lib/report.js';
+import { QuotaExceededError } from '../lib/retry.js';
 import type { RunResult, ChallengeConfig } from '../lib/types.js';
 
 export const analyzeCommand = new Command('analyze')
@@ -16,15 +17,17 @@ export const analyzeCommand = new Command('analyze')
   .option('--reanalyze', 'Re-analyze even if analysis already exists')
   .option('-c, --challenge <id>', 'Override challenge ID for loading config')
   .option('--model <model>', 'Analyzer model (default: claude-sonnet-4-5-20250929)')
-  .option('-k, --api-key <key>', 'Anthropic API key for analysis')
+  .option('-k, --api-key <key>', 'API key for analysis')
+  .option('-p, --provider <provider>', 'Provider for analysis (default: anthropic)')
+  .option('--api-url <url>', 'Custom API endpoint for analyzer')
   .action(async (runId, options) => {
-    const apiKey = options.apiKey || getApiKey('anthropic') || process.env.ANTHROPIC_API_KEY;
+    const analyzerProvider = normalizeProvider(options.provider || 'anthropic');
+    const apiKey = options.apiKey || getApiKey(analyzerProvider);
 
-    if (!apiKey) {
-      console.error(colors.red(`\n${status.error} Analysis requires an Anthropic API key.`));
+    if (!apiKey && analyzerProvider !== 'ollama') {
+      console.error(colors.red(`\n${status.error} Analysis requires an API key for ${analyzerProvider}.`));
       console.log(colors.gray(`  Configure via:`));
-      console.log(colors.gray(`    oasis config set api-key anthropic <your-key>`));
-      console.log(colors.gray(`  Or set: ANTHROPIC_API_KEY=<your-key>`));
+      console.log(colors.gray(`    oasis config set api-key ${analyzerProvider} <your-key>`));
       process.exit(1);
     }
 
@@ -108,6 +111,8 @@ export const analyzeCommand = new Command('analyze')
         const analysis = await analyzeRun(result, {
           apiKey,
           analyzerModel: options.model,
+          provider: analyzerProvider,
+          baseUrl: options.apiUrl || getEffectiveProviderUrl(analyzerProvider) || undefined,
           challengeTarget: challengeConfig?.target || `Challenge: ${challengeId}`,
           challengeConfig,
         });
@@ -123,8 +128,18 @@ export const analyzeCommand = new Command('analyze')
           console.log(colors.gray(`  Score: ${score}/100 | Approach: ${analysis.behavior.approach}`));
         }
       } catch (error) {
-        spinner.fail(`Analysis failed for ${id}`);
-        console.error(colors.red(`  ${error instanceof Error ? error.message : 'Unknown error'}`));
+        if (error instanceof QuotaExceededError) {
+          spinner.fail(`Analysis failed for ${id} — API quota or rate limit reached`);
+          console.log();
+          console.log(colors.gray(`  Your benchmark results are safe. Retry anytime.`));
+          console.log();
+          console.log(colors.gray(`  Next steps:`));
+          console.log(colors.gray(`    - Retry with another provider:  oasis analyze ${id} -p <provider>`));
+          console.log(colors.gray(`    - Retry later:                  oasis analyze ${id}`));
+        } else {
+          spinner.fail(`Analysis failed for ${id}`);
+          console.error(colors.red(`  ${error instanceof Error ? error.message : 'Unknown error'}`));
+        }
       }
     }
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -7,8 +7,8 @@ import { getApiKey, getConfigValue, normalizeProvider, getEffectiveProviderUrl, 
 import { runBenchmark, saveRunResult, saveAnalysisResult } from '../lib/runner.js';
 import { analyzeRun } from '../lib/analyzer.js';
 import { printColorReport, printAnalysisSummary } from '../lib/report.js';
-import { isAnthropicProvider } from '../lib/providers.js';
 import { runPreflightChecks, checkApiKey } from '../lib/env-check.js';
+import { QuotaExceededError } from '../lib/retry.js';
 import type { ChallengeConfig, RunnerConfig } from '../lib/types.js';
 
 export const runCommand = new Command('run')
@@ -22,6 +22,8 @@ export const runCommand = new Command('run')
   .option('--no-analyze', 'Skip post-run analysis')
   .option('--analyzer-model <model>', 'Model for analysis (default: claude-sonnet-4-5-20250929)')
   .option('--analyzer-key <key>', 'Separate API key for analysis (defaults to anthropic key)')
+  .option('--analyzer-provider <provider>', 'Provider for analysis (default: same as benchmark or anthropic)')
+  .option('--analyzer-url <url>', 'Custom API endpoint for analyzer')
   .option('--max-iterations <n>', 'Override max iterations', parseInt)
   .option('--report', 'Print detailed report after run', false)
   .option('--verbose', 'Show detailed output', false)
@@ -128,6 +130,17 @@ export const runCommand = new Command('run')
       process.exit(1);
     }
 
+    // Resolve analyzer config early (needed for pre-run quota probe)
+    const analyzerProvider = analyze
+      ? normalizeProvider(options.analyzerProvider || provider)
+      : '';
+    const analyzerApiKey = analyze
+      ? (options.analyzerKey || getApiKey(analyzerProvider) || resolvedApiKey)
+      : undefined;
+    const analyzerBaseUrl = analyze
+      ? (options.analyzerUrl || getEffectiveProviderUrl(analyzerProvider) || undefined)
+      : undefined;
+
     // Display run info
     console.log();
     console.log(colors.gray(`Challenge: ${challengeConfig.name || challenge}`));
@@ -196,19 +209,12 @@ export const runCommand = new Command('run')
 
       // Run analysis
       if (analyze) {
-        const analyzerApiKey = options.analyzerKey || getApiKey('anthropic') || resolvedApiKey;
-
-        if (!analyzerApiKey || !isAnthropicProvider('anthropic')) {
-          // Need an Anthropic key for analysis
-          const hasAnthropicKey = getApiKey('anthropic') || process.env.ANTHROPIC_API_KEY;
-          if (!hasAnthropicKey && !isAnthropicProvider(provider)) {
-            console.log();
-            console.log(colors.yellow(`${status.warning} Analysis requires an Anthropic API key.`));
-            console.log(colors.gray(`  Configure via: oasis config set api-key anthropic <your-key>`));
-            console.log(colors.gray(`  Or set: ANTHROPIC_API_KEY=<your-key>`));
-            console.log(colors.gray(`  To skip analysis: oasis run --no-analyze ...`));
-            return;
-          }
+        if (!analyzerApiKey && analyzerProvider !== 'ollama') {
+          console.log();
+          console.log(colors.yellow(`${status.warning} Analysis requires an API key for ${analyzerProvider}.`));
+          console.log(colors.gray(`  Configure via: oasis config set api-key ${analyzerProvider} <your-key>`));
+          console.log(colors.gray(`  To skip analysis: oasis run --no-analyze ...`));
+          return;
         }
 
         const spinnerAnalysis = ora({
@@ -218,8 +224,10 @@ export const runCommand = new Command('run')
 
         try {
           const analysis = await analyzeRun(result, {
-            apiKey: options.analyzerKey || getApiKey('anthropic') || process.env.ANTHROPIC_API_KEY || resolvedApiKey,
+            apiKey: analyzerApiKey,
             analyzerModel: options.analyzerModel,
+            provider: analyzerProvider,
+            baseUrl: analyzerBaseUrl,
             challengeTarget: challengeConfig.target,
             challengeConfig,
           });
@@ -249,9 +257,20 @@ export const runCommand = new Command('run')
 
           console.log(colors.gray(`Analysis saved to: ${analysisPath}`));
         } catch (analysisError) {
-          spinnerAnalysis.fail('Analysis failed');
-          console.error(colors.red(`  ${analysisError instanceof Error ? analysisError.message : 'Unknown error'}`));
-          console.log(colors.gray(`  Retry later with: oasis analyze ${result.id}`));
+          if (analysisError instanceof QuotaExceededError) {
+            spinnerAnalysis.fail('Analysis failed — API quota or rate limit reached');
+            console.log();
+            console.log(colors.gray(`  Your benchmark results are saved (run ${result.id}).`));
+            console.log(colors.gray(`  Retry analysis anytime without re-running the benchmark.`));
+            console.log();
+            console.log(colors.gray(`  Next steps:`));
+            console.log(colors.gray(`    - Retry with another provider:  oasis analyze ${result.id} -p <provider>`));
+            console.log(colors.gray(`    - Retry later:                  oasis analyze ${result.id}`));
+          } else {
+            spinnerAnalysis.fail('Analysis failed');
+            console.error(colors.red(`  ${analysisError instanceof Error ? analysisError.message : 'Unknown error'}`));
+            console.log(colors.gray(`  Retry later with: oasis analyze ${result.id}`));
+          }
         }
       } else {
         // No analysis, just print basic stats

--- a/src/lib/analyzer.ts
+++ b/src/lib/analyzer.ts
@@ -1,8 +1,9 @@
 // OASIS Attack Chain Analyzer
-// Uses LLM (Claude) to provide deep analysis of benchmark runs
-// Open-source: works with user's own Anthropic API key
+// Uses LLM to provide deep analysis of benchmark runs
+// Supports Anthropic (native SDK) and OpenAI-compatible providers
 
 import Anthropic from '@anthropic-ai/sdk';
+import OpenAI from 'openai';
 import type {
   RunResult,
   AnalysisResult,
@@ -18,6 +19,7 @@ import {
   finalizeRubricScore,
 } from './scoring.js';
 import { withRateLimitRetry } from './retry.js';
+import { isAnthropicProvider, resolveProvider } from './providers.js';
 
 // =============================================================================
 // Configuration
@@ -401,46 +403,105 @@ function buildRubricScore(
 export interface AnalyzeOptions {
   apiKey?: string;
   analyzerModel?: string;
+  provider?: string;       // 'anthropic', 'openai', 'xai', 'google', 'ollama', 'custom'
+  baseUrl?: string;        // Custom endpoint URL for OpenAI-compatible providers
   challengeTarget?: string;
   challengeConfig?: ChallengeConfig;
 }
 
-export async function analyzeRun(
-  result: RunResult,
-  options: AnalyzeOptions = {}
-): Promise<AnalysisResult> {
-  const apiKey = options.apiKey || process.env.ANTHROPIC_API_KEY || process.env.ANALYZER_API_KEY;
+function resolveDefaultAnalyzerModel(provider: string): string {
+  if (isAnthropicProvider(provider)) return DEFAULT_ANALYZER_MODEL;
+  const preset = resolveProvider(provider);
+  return preset?.models[0] || DEFAULT_ANALYZER_MODEL;
+}
 
-  if (!apiKey) {
-    throw new Error(
-      'No Anthropic API key provided for analysis.\n' +
-      'Set ANTHROPIC_API_KEY environment variable or configure via:\n' +
-      '  oasis config set api-key anthropic <your-key>'
-    );
-  }
-
-  const analyzerModel = options.analyzerModel || DEFAULT_ANALYZER_MODEL;
+async function callAnthropicAnalyzer(
+  apiKey: string, model: string, prompt: string
+): Promise<string> {
   const client = new Anthropic({ apiKey });
-
-  const challengeTarget = options.challengeTarget || `Challenge: ${result.challenge}`;
-  const prompt = buildAnalysisPrompt(result, challengeTarget, options.challengeConfig);
-
   const response = await withRateLimitRetry(
     () => client.messages.create({
-      model: analyzerModel,
+      model,
       max_tokens: 4096,
       system: SYSTEM_PROMPT,
       messages: [{ role: 'user', content: prompt }],
     }),
     'Analysis',
   );
-
   const textContent = response.content.find(c => c.type === 'text');
   if (!textContent || textContent.type !== 'text') {
     throw new Error('No text response from analyzer');
   }
+  return textContent.text;
+}
 
-  return parseAnalysisResponse(textContent.text, result.id, result, options.challengeConfig);
+async function callOpenAIAnalyzer(
+  apiKey: string | undefined, baseURL: string | undefined,
+  model: string, prompt: string
+): Promise<string> {
+  const client = new OpenAI({ apiKey, baseURL });
+  const response = await withRateLimitRetry(
+    () => client.chat.completions.create({
+      model,
+      max_completion_tokens: 4096,
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: prompt },
+      ],
+    }),
+    'Analysis',
+  );
+  const content = response.choices[0]?.message?.content;
+  if (!content) {
+    throw new Error('No text response from analyzer');
+  }
+  return content;
+}
+
+export async function analyzeRun(
+  result: RunResult,
+  options: AnalyzeOptions = {}
+): Promise<AnalysisResult> {
+  const provider = options.provider || 'anthropic';
+  const useAnthropic = isAnthropicProvider(provider);
+
+  // Resolve API key — try option, then provider-specific env, then fallback
+  const apiKey = options.apiKey
+    || (useAnthropic
+      ? (process.env.ANTHROPIC_API_KEY || process.env.ANALYZER_API_KEY)
+      : undefined);
+
+  // For non-Anthropic providers that need a key
+  if (!apiKey && provider !== 'ollama') {
+    const providerPreset = resolveProvider(provider);
+    const envHint = providerPreset?.envKey || `${provider.toUpperCase()}_API_KEY`;
+    throw new Error(
+      `No API key provided for ${provider} analysis.\n` +
+      `Set ${envHint} environment variable or configure via:\n` +
+      `  oasis config set api-key ${provider} <your-key>`
+    );
+  }
+
+  // Resolve model — default per provider
+  const analyzerModel = options.analyzerModel || resolveDefaultAnalyzerModel(provider);
+
+  // Resolve base URL for OpenAI-compatible providers
+  const baseUrl = options.baseUrl || (!useAnthropic
+    ? (resolveProvider(provider)?.baseUrl || undefined)
+    : undefined);
+
+  const challengeTarget = options.challengeTarget || `Challenge: ${result.challenge}`;
+  const prompt = buildAnalysisPrompt(result, challengeTarget, options.challengeConfig);
+
+  let responseText: string;
+
+  if (useAnthropic) {
+    responseText = await callAnthropicAnalyzer(apiKey!, analyzerModel, prompt);
+  } else {
+    responseText = await callOpenAIAnalyzer(apiKey, baseUrl, analyzerModel, prompt);
+  }
+
+  return parseAnalysisResponse(responseText, result.id, result, options.challengeConfig);
 }
 
 export async function analyzeExistingRun(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -211,10 +211,10 @@ export function listProviderUrls(): Record<string, string> {
 // Default URLs for providers
 const DEFAULT_PROVIDER_URLS: Record<string, string> = {
   anthropic: 'https://api.anthropic.com',
-  openai: 'https://api.openai.com',
-  xai: 'https://api.x.ai',
-  google: 'https://generativelanguage.googleapis.com',
-  ollama: 'http://localhost:11434',
+  openai: 'https://api.openai.com/v1',
+  xai: 'https://api.x.ai/v1',
+  google: 'https://generativelanguage.googleapis.com/v1beta/openai',
+  ollama: 'http://localhost:11434/v1',
 };
 
 export function getEffectiveProviderUrl(provider: string): string {

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -83,3 +83,4 @@ export function isAnthropicProvider(provider: string): boolean {
   const resolved = resolveProviderName(provider);
   return resolved === 'anthropic';
 }
+

--- a/src/lib/retry.ts
+++ b/src/lib/retry.ts
@@ -5,6 +5,29 @@ import chalk from 'chalk';
 export const RATE_LIMIT_MAX_RETRIES = 3;
 export const RATE_LIMIT_BASE_DELAY_MS = 2000;
 
+export class QuotaExceededError extends Error {
+  constructor(
+    message: string,
+    public readonly provider?: string,
+    public readonly model?: string,
+  ) {
+    super(message);
+    this.name = 'QuotaExceededError';
+  }
+}
+
+export function isQuotaExceededError(error: unknown): boolean {
+  const err = error as {
+    code?: string; message?: string;
+    error?: { code?: string; message?: string };
+  };
+  if (err?.code === 'insufficient_quota') return true;
+  if (err?.error?.code === 'insufficient_quota') return true;
+  if (typeof err?.message === 'string' &&
+      err.message.toLowerCase().includes('exceeded your current quota')) return true;
+  return false;
+}
+
 export function getErrorStatus(error: unknown): number | undefined {
   const err = error as { status?: number; statusCode?: number; response?: { status?: number } };
   return err?.status ?? err?.statusCode ?? err?.response?.status;
@@ -50,6 +73,13 @@ export async function withRateLimitRetry<T>(
     } catch (error) {
       lastError = error;
       const status = getErrorStatus(error);
+
+      if (status === 429 && isQuotaExceededError(error)) {
+        throw new QuotaExceededError(
+          `API quota reached — retrying won't help`,
+        );
+      }
+
       const isRetryable = isRetryableStatus(status);
       const hasAttemptsLeft = attempt < RATE_LIMIT_MAX_RETRIES;
 

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -49,19 +49,19 @@ describe('getEffectiveProviderUrl', () => {
   });
 
   it('returns openai API URL', () => {
-    expect(getEffectiveProviderUrl('openai')).toBe('https://api.openai.com');
+    expect(getEffectiveProviderUrl('openai')).toBe('https://api.openai.com/v1');
   });
 
   it('returns xai API URL', () => {
-    expect(getEffectiveProviderUrl('xai')).toBe('https://api.x.ai');
+    expect(getEffectiveProviderUrl('xai')).toBe('https://api.x.ai/v1');
   });
 
   it('returns google API URL', () => {
-    expect(getEffectiveProviderUrl('google')).toBe('https://generativelanguage.googleapis.com');
+    expect(getEffectiveProviderUrl('google')).toBe('https://generativelanguage.googleapis.com/v1beta/openai');
   });
 
   it('returns ollama localhost URL', () => {
-    expect(getEffectiveProviderUrl('ollama')).toBe('http://localhost:11434');
+    expect(getEffectiveProviderUrl('ollama')).toBe('http://localhost:11434/v1');
   });
 
   it('resolves aliases (claude -> anthropic URL)', () => {
@@ -69,11 +69,11 @@ describe('getEffectiveProviderUrl', () => {
   });
 
   it('resolves aliases (grok -> xai URL)', () => {
-    expect(getEffectiveProviderUrl('grok')).toBe('https://api.x.ai');
+    expect(getEffectiveProviderUrl('grok')).toBe('https://api.x.ai/v1');
   });
 
   it('resolves aliases (gemini -> google URL)', () => {
-    expect(getEffectiveProviderUrl('gemini')).toBe('https://generativelanguage.googleapis.com');
+    expect(getEffectiveProviderUrl('gemini')).toBe('https://generativelanguage.googleapis.com/v1beta/openai');
   });
 
   it('returns empty string for unknown providers', () => {

--- a/tests/unit/retry.test.ts
+++ b/tests/unit/retry.test.ts
@@ -7,6 +7,8 @@ import {
   withRateLimitRetry,
   RATE_LIMIT_MAX_RETRIES,
   RATE_LIMIT_BASE_DELAY_MS,
+  QuotaExceededError,
+  isQuotaExceededError,
 } from '../../src/lib/retry.js';
 
 // =============================================================================
@@ -194,5 +196,114 @@ describe('withRateLimitRetry', () => {
 
     expect((outcome as any).caught).toEqual(error429);
     expect(fn).toHaveBeenCalledTimes(RATE_LIMIT_MAX_RETRIES + 1);
+  });
+
+  it('throws QuotaExceededError immediately on quota 429 (no retries)', async () => {
+    const quotaError = { status: 429, code: 'insufficient_quota', message: 'You exceeded your current quota' };
+    const fn = vi.fn().mockRejectedValue(quotaError);
+
+    await expect(withRateLimitRetry(fn, 'test')).rejects.toBeInstanceOf(QuotaExceededError);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('still retries transient rate-limit 429s', async () => {
+    const rateLimitError = { status: 429, code: 'rate_limit_exceeded' };
+    const fn = vi.fn()
+      .mockRejectedValueOnce(rateLimitError)
+      .mockResolvedValue('ok');
+
+    vi.useFakeTimers();
+    const promise = withRateLimitRetry(fn, 'test');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    vi.useRealTimers();
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('still retries plain 429s with no code', async () => {
+    const plain429 = { status: 429 };
+    const fn = vi.fn()
+      .mockRejectedValueOnce(plain429)
+      .mockResolvedValue('ok');
+
+    vi.useFakeTimers();
+    const promise = withRateLimitRetry(fn, 'test');
+    await vi.runAllTimersAsync();
+    const result = await promise;
+    vi.useRealTimers();
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});
+
+// =============================================================================
+// isQuotaExceededError
+// =============================================================================
+
+describe('isQuotaExceededError', () => {
+  it('returns true for code: insufficient_quota', () => {
+    expect(isQuotaExceededError({ code: 'insufficient_quota' })).toBe(true);
+  });
+
+  it('returns true for nested error.error.code: insufficient_quota', () => {
+    expect(isQuotaExceededError({ error: { code: 'insufficient_quota' } })).toBe(true);
+  });
+
+  it('returns true for message containing "exceeded your current quota"', () => {
+    expect(isQuotaExceededError({ message: 'You exceeded your current quota, please check your plan.' })).toBe(true);
+  });
+
+  it('returns true for message with different casing', () => {
+    expect(isQuotaExceededError({ message: 'You Exceeded Your Current Quota' })).toBe(true);
+  });
+
+  it('returns false for code: rate_limit_exceeded', () => {
+    expect(isQuotaExceededError({ code: 'rate_limit_exceeded' })).toBe(false);
+  });
+
+  it('returns false for plain 429 with no code or message', () => {
+    expect(isQuotaExceededError({ status: 429 })).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isQuotaExceededError(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isQuotaExceededError(undefined)).toBe(false);
+  });
+});
+
+// =============================================================================
+// QuotaExceededError
+// =============================================================================
+
+describe('QuotaExceededError', () => {
+  it('is an instance of Error', () => {
+    const err = new QuotaExceededError('test');
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it('has correct name', () => {
+    const err = new QuotaExceededError('test');
+    expect(err.name).toBe('QuotaExceededError');
+  });
+
+  it('stores provider', () => {
+    const err = new QuotaExceededError('test', 'openai');
+    expect(err.provider).toBe('openai');
+  });
+
+  it('stores model', () => {
+    const err = new QuotaExceededError('test', 'google', 'gemini-2.0-flash');
+    expect(err.model).toBe('gemini-2.0-flash');
+  });
+
+  it('has correct message', () => {
+    const err = new QuotaExceededError('quota exceeded');
+    expect(err.message).toBe('quota exceeded');
   });
 });


### PR DESCRIPTION
## Summary

- **Multi-provider analyzer**: Users can now analyze benchmarks with the same provider they ran them on (OpenAI, xAI, Google, Ollama, custom) instead of requiring a separate Anthropic API key
- **Quota-exceeded fail-fast**: 429s with `insufficient_quota` code are detected immediately — no more wasting ~14s on retries that will never succeed
- **User-friendly error messages**: When quota errors hit during analysis, users get clear guidance on retrying with a different provider or later

## Changes

| File | What |
|------|------|
| `src/lib/retry.ts` | `QuotaExceededError` class, `isQuotaExceededError()`, fail-fast in retry loop |
| `src/lib/analyzer.ts` | `callOpenAIAnalyzer()`, multi-provider dispatch, provider/model resolution |
| `src/commands/run.ts` | `--analyzer-provider`, `--analyzer-url` flags, quota error handling |
| `src/commands/analyze.ts` | `-p`, `--api-url` flags, multi-provider support, quota error handling |
| `src/lib/config.ts` | Provider base URLs updated with `/v1` paths for OpenAI SDK compat |
| `src/lib/providers.ts` | Minor cleanup |
| `tests/unit/retry.test.ts` | 15 new tests for quota detection and fail-fast behavior |
| `tests/unit/config.test.ts` | Updated URL expectations |
