### PR TITLE
fix: prevent command injection via containerName in runner

### DIFF
--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -18,12 +18,21 @@ const FLAG_PATTERN = /KX\{[a-f0-9]+\}/i;
 // Command Execution
 // =============================================================================
 
+/** Escape a string for safe inclusion in a shell command (single-quote wrapping). */
+function shellEscape(s: string): string {
+  return "'" + s.replace(/'/g, "'\\''") + "'";
+}
+
+export function buildDockerExecCommand(command: string, containerName: string): string {
+  return `docker exec ${shellEscape(containerName)} bash -c ${shellEscape(command)}`;
+}
+
 function executeCommand(command: string, containerName: string, verbose: boolean): string {
   if (verbose) {
     console.log(chalk.yellow(`\n> ${command}`));
   }
   try {
-    const execCommand = `docker exec ${containerName} bash -c "${command.replace(/"/g, '\\"')}"`;
+    const execCommand = buildDockerExecCommand(command, containerName);
     const result = execSync(execCommand, {
       encoding: 'utf-8',
       timeout: 60000,

--- a/tests/unit/runner.test.ts
+++ b/tests/unit/runner.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { buildDockerExecCommand } from '../../src/lib/runner.js';
+
+describe('buildDockerExecCommand', () => {
+  it('wraps container and command in single quotes', () => {
+    const result = buildDockerExecCommand('ls -la', 'gatekeeper-kali-1');
+    expect(result).toBe("docker exec 'gatekeeper-kali-1' bash -c 'ls -la'");
+  });
+
+  it('escapes single quotes in containerName', () => {
+    const result = buildDockerExecCommand('id', "evil'name");
+    expect(result).toBe("docker exec 'evil'\\''name' bash -c 'id'");
+  });
+
+  it('escapes single quotes in command text', () => {
+    const result = buildDockerExecCommand("echo 'hello'", 'kali');
+    expect(result).toBe("docker exec 'kali' bash -c 'echo '\\''hello'\\'''");
+  });
+
+  it('prevents containerName shell-breakout patterns from becoming bare tokens', () => {
+    const result = buildDockerExecCommand('ls -la', "test'; rm -rf /tmp/test; echo 'foo\"");
+    expect(result).toContain("docker exec 'test'\\''; rm -rf /tmp/test; echo '\\''foo\"' bash -c 'ls -la'");
+    expect(result).not.toContain("docker exec test';");
+  });
+});


### PR DESCRIPTION
## Summary
- escape containerName and command before docker exec shell invocation
- centralize command construction in buildDockerExecCommand for clarity and testability
- add runner unit tests for quote escaping and injection patterns

## Validation
- npm run typecheck
- npm run test -- tests/unit/runner.test.ts

Closes #10