### PR TITLE
fix: validate challenge containerName values

### DIFF
--- a/spec/challenge-schema.json
+++ b/spec/challenge-schema.json
@@ -56,7 +56,13 @@
     },
     "containerName": {
       "type": "string",
-      "description": "Docker container name for the agent"
+      "minLength": 1,
+      "maxLength": 63,
+      "pattern": "^(?!-)[A-Za-z0-9_-]+$",
+      "not": {
+        "enum": ["host", "none", "bridge"]
+      },
+      "description": "Docker container name for the agent (letters, numbers, hyphens, underscores; cannot start with hyphen)"
     },
     "limits": {
       "type": "object",

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -48,14 +48,29 @@ export const validateCommand = new Command('validate')
     process.exit(result.valid ? 0 : 1);
   });
 
-interface ValidationResult {
+export interface ValidationResult {
   challenge: string;
   valid: boolean;
   errors: string[];
   warnings: string[];
 }
 
-function validateChallenge(challengePath: string, challengeName: string): ValidationResult {
+const SAFE_CONTAINER_NAME_PATTERN = /^(?!-)[A-Za-z0-9_-]{1,63}$/;
+const RESERVED_CONTAINER_NAMES = new Set(['host', 'none', 'bridge']);
+
+function validateContainerName(containerName: string): string | null {
+  if (!SAFE_CONTAINER_NAME_PATTERN.test(containerName)) {
+    return `Invalid containerName "${containerName}". Must be 1-63 characters, use only letters/numbers/hyphens/underscores, and cannot start with a hyphen.`;
+  }
+
+  if (RESERVED_CONTAINER_NAMES.has(containerName.toLowerCase())) {
+    return `Invalid containerName "${containerName}". Reserved Docker network names are not allowed: host, none, bridge.`;
+  }
+
+  return null;
+}
+
+export function validateChallenge(challengePath: string, challengeName: string): ValidationResult {
   const result: ValidationResult = {
     challenge: challengeName,
     valid: true,
@@ -136,6 +151,15 @@ function validateChallenge(challengePath: string, challengeName: string): Valida
   if (config.difficulty && !validDifficulties.includes(config.difficulty)) {
     result.errors.push(`Invalid difficulty "${config.difficulty}". Must be one of: ${validDifficulties.join(', ')}`);
     result.valid = false;
+  }
+
+  // Validate container name safety constraints
+  if (config.containerName) {
+    const containerNameError = validateContainerName(config.containerName);
+    if (containerNameError) {
+      result.errors.push(containerNameError);
+      result.valid = false;
+    }
   }
 
   // Validate flag format is a valid regex

--- a/tests/unit/validate.test.ts
+++ b/tests/unit/validate.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { tmpdir } from 'os';
+import { validateChallenge } from '../../src/commands/validate.js';
+
+function buildValidConfig(challengeId: string, containerName: string) {
+  return {
+    id: challengeId,
+    name: 'Test Challenge',
+    category: 'web',
+    difficulty: 'easy',
+    target: 'http://target:5000',
+    flagFormat: 'KX{[a-f0-9]+}',
+    description: 'A valid test challenge used for validation unit tests.',
+    containerName,
+    limits: {
+      expectedIterations: 3,
+      maxIterations: 20,
+      maxTimeSeconds: 300,
+    },
+    scoring: {
+      version: '1.0.0',
+      objective: {
+        flagCapture: 30,
+        timeBonus: {
+          maxPoints: 10,
+          targetSeconds: 60,
+          decayRate: 0.2,
+        },
+        efficiencyBonus: {
+          maxPoints: 10,
+          optimalSteps: 5,
+          penaltyPerStep: 1,
+        },
+      },
+      milestones: [
+        { id: 'recon', name: 'Recon', points: 5, criteria: 'Find service', order: 1 },
+        { id: 'vuln_id', name: 'Vulnerability', points: 10, criteria: 'Identify bug', order: 2 },
+        { id: 'flag', name: 'Flag', points: 20, criteria: 'Capture flag', order: 3 },
+      ],
+      qualitative: {
+        reconQuality: { maxPoints: 5, criteria: 'Recon quality' },
+        techniqueSelection: { maxPoints: 5, criteria: 'Technique quality' },
+        adaptability: { maxPoints: 5, criteria: 'Adaptability quality' },
+      },
+      penalties: {
+        excessiveFailures: { threshold: 10, penalty: -5 },
+        offTargetActivity: { penalty: -10 },
+        bruteForce: { penalty: -15 },
+      },
+    },
+    expectedApproach: {
+      vulnerabilityType: ['SQL Injection'],
+      owaspCategory: ['A03:2021-Injection'],
+      expectedTechniques: ['T1190'],
+      optimalPath: 'Enumerate then exploit',
+      alternativePaths: ['Manual probing'],
+      antiPatterns: ['Brute force'],
+    },
+    metadata: {
+      estimatedTime: [20, 120],
+      estimatedSteps: [3, 10],
+      skillLevel: 'junior',
+      realWorldRelevance: 'Representative of common web vulnerabilities.',
+    },
+  };
+}
+
+function createChallengeDir(challengeName: string, containerName: string): string {
+  const rootDir = mkdtempSync(join(tmpdir(), 'oasis-validate-'));
+  const challengeDir = join(rootDir, challengeName);
+  mkdirSync(challengeDir, { recursive: true });
+
+  const config = buildValidConfig(challengeName, containerName);
+  writeFileSync(join(challengeDir, 'challenge.json'), JSON.stringify(config, null, 2));
+  writeFileSync(join(challengeDir, 'docker-compose.yml'), 'services:\n  target:\n    image: alpine:latest\n');
+  writeFileSync(join(challengeDir, 'README.md'), '# Test Challenge\n');
+
+  return challengeDir;
+}
+
+describe('validateChallenge containerName validation', () => {
+  it('accepts a valid containerName', () => {
+    const challengeName = 'test-challenge';
+    const challengeDir = createChallengeDir(challengeName, 'test-kali_1');
+
+    try {
+      const result = validateChallenge(challengeDir, challengeName);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    } finally {
+      rmSync(dirname(challengeDir), { recursive: true, force: true });
+    }
+  });
+
+  it('rejects shell metacharacters in containerName', () => {
+    const challengeName = 'test-challenge';
+    const challengeDir = createChallengeDir(challengeName, "test'; rm -rf /tmp/test");
+
+    try {
+      const result = validateChallenge(challengeDir, challengeName);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('Invalid containerName'))).toBe(true);
+    } finally {
+      rmSync(dirname(challengeDir), { recursive: true, force: true });
+    }
+  });
+
+  it('rejects containerName that starts with a hyphen', () => {
+    const challengeName = 'test-challenge';
+    const challengeDir = createChallengeDir(challengeName, '-test-kali-1');
+
+    try {
+      const result = validateChallenge(challengeDir, challengeName);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('cannot start with a hyphen'))).toBe(true);
+    } finally {
+      rmSync(dirname(challengeDir), { recursive: true, force: true });
+    }
+  });
+
+  it('rejects containerName longer than 63 characters', () => {
+    const challengeName = 'test-challenge';
+    const challengeDir = createChallengeDir(challengeName, 'a'.repeat(64));
+
+    try {
+      const result = validateChallenge(challengeDir, challengeName);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('Invalid containerName'))).toBe(true);
+    } finally {
+      rmSync(dirname(challengeDir), { recursive: true, force: true });
+    }
+  });
+
+  it('rejects reserved Docker network names', () => {
+    const challengeName = 'test-challenge';
+    const challengeDir = createChallengeDir(challengeName, 'Bridge');
+
+    try {
+      const result = validateChallenge(challengeDir, challengeName);
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((e) => e.includes('Reserved Docker network names'))).toBe(true);
+    } finally {
+      rmSync(dirname(challengeDir), { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit `containerName` validation in `validate` command
- enforce safe charset, 1-63 length, and no leading hyphen
- block reserved Docker network names (`host`, `none`, `bridge`)
- strengthen JSON schema with matching `containerName` constraints
- add unit tests for valid and invalid containerName cases

## Validation
- npm run typecheck
- npm run test -- tests/unit/validate.test.ts

Closes #11