### PR TITLE
fix: prevent run-id path traversal in result commands

### DIFF
--- a/src/commands/analyze.ts
+++ b/src/commands/analyze.ts
@@ -4,7 +4,8 @@ import { resolve as pathResolve } from 'path';
 import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { colors, status } from '../lib/display.js';
 import { calculateKSS } from '../lib/scoring.js';
-import { getApiKey, getConfigValue, normalizeProvider, getEffectiveProviderUrl, getChallengesDir, getResultsDir } from '../lib/config.js';
+import { getApiKey, normalizeProvider, getEffectiveProviderUrl, getChallengesDir, getResultsDir } from '../lib/config.js';
+import { resolveAnalysisPath, resolveResultPath, InvalidRunIdError, ResultPathEscapeError } from '../lib/results-path.js';
 import { analyzeRun } from '../lib/analyzer.js';
 import { saveAnalysisResult } from '../lib/runner.js';
 import { printAnalysisSummary } from '../lib/report.js';
@@ -47,7 +48,15 @@ export const analyzeCommand = new Command('analyze')
 
       for (const file of files) {
         const id = file.replace('.json', '');
-        const analysisPath = pathResolve(getResultsDir(), `${id}.analysis.json`);
+        let analysisPath: string;
+        try {
+          analysisPath = resolveAnalysisPath(id);
+        } catch (error) {
+          if (error instanceof InvalidRunIdError || error instanceof ResultPathEscapeError) {
+            continue;
+          }
+          throw error;
+        }
         if (options.reanalyze || !existsSync(analysisPath)) {
           runIds.push(id);
         }
@@ -83,7 +92,20 @@ export const analyzeCommand = new Command('analyze')
     const challengesDir = getChallengesDir();
 
     for (const id of runIds) {
-      const resultPath = pathResolve(getResultsDir(), `${id}.json`);
+      let resultPath: string;
+      try {
+        resultPath = resolveResultPath(id);
+      } catch (error) {
+        if (error instanceof InvalidRunIdError || error instanceof ResultPathEscapeError) {
+          console.error(colors.red(`${status.error} Invalid run ID: ${error.runId}`));
+          console.log(colors.gray('  Use only letters, numbers, "_" or "-".'));
+          if (runIds.length === 1) {
+            process.exit(1);
+          }
+          continue;
+        }
+        throw error;
+      }
 
       if (!existsSync(resultPath)) {
         console.error(colors.red(`${status.error} Run not found: ${id}`));

--- a/src/commands/report.ts
+++ b/src/commands/report.ts
@@ -1,8 +1,7 @@
 import { Command } from 'commander';
-import { resolve as pathResolve } from 'path';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { colors, status } from '../lib/display.js';
-import { getResultsDir } from '../lib/config.js';
+import { resolveAnalysisPath, resolveResultPath, InvalidRunIdError, ResultPathEscapeError } from '../lib/results-path.js';
 import {
   printColorReport,
   generateTextReport,
@@ -20,7 +19,20 @@ export const reportCommand = new Command('report')
   .option('-f, --format <format>', 'Output format: terminal, text, json, md', 'terminal')
   .option('-o, --output <path>', 'Write report to file (instead of stdout)')
   .action((runId, options) => {
-    const resultPath = pathResolve(getResultsDir(), `${runId}.json`);
+    let resultPath: string;
+    let analysisPath: string;
+    try {
+      resultPath = resolveResultPath(runId);
+      analysisPath = resolveAnalysisPath(runId);
+    } catch (error) {
+      if (error instanceof InvalidRunIdError || error instanceof ResultPathEscapeError) {
+        console.error(colors.red(`\n${status.error} Invalid run ID: ${runId}`));
+        console.log(colors.gray('  Use only letters, numbers, "_" or "-".'));
+        process.exit(1);
+      }
+      throw error;
+    }
+
     if (!existsSync(resultPath)) {
       console.error(colors.red(`\n${status.error} Run not found: ${runId}`));
       process.exit(1);
@@ -29,7 +41,6 @@ export const reportCommand = new Command('report')
     const result: RunResult = JSON.parse(readFileSync(resultPath, 'utf-8'));
 
     // Load analysis if available
-    const analysisPath = pathResolve(getResultsDir(), `${runId}.analysis.json`);
     let analysis: AnalysisResult | undefined;
     if (existsSync(analysisPath)) {
       try {

--- a/src/commands/results.ts
+++ b/src/commands/results.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'fs';
 import { colors, status, formatScore, formatTime, formatDifficulty } from '../lib/display.js';
 import { calculateKSS } from '../lib/scoring.js';
 import { getResultsDir, getChallengesDir } from '../lib/config.js';
+import { resolveAnalysisPath, resolveResultPath, InvalidRunIdError, ResultPathEscapeError } from '../lib/results-path.js';
 import type { RunResult, AnalysisResult, ChallengeConfig } from '../lib/types.js';
 
 export const resultsCommand = new Command('results')
@@ -93,7 +94,20 @@ resultsCommand
   .description('Show details of a specific run')
   .argument('<run-id>', 'Run ID to show')
   .action((runId) => {
-    const resultPath = pathResolve(getResultsDir(), `${runId}.json`);
+    let resultPath: string;
+    let analysisPath: string;
+    try {
+      resultPath = resolveResultPath(runId);
+      analysisPath = resolveAnalysisPath(runId);
+    } catch (error) {
+      if (error instanceof InvalidRunIdError || error instanceof ResultPathEscapeError) {
+        console.error(colors.red(`\n${status.error} Invalid run ID: ${runId}`));
+        console.log(colors.gray('  Use only letters, numbers, "_" or "-".'));
+        process.exit(1);
+      }
+      throw error;
+    }
+
     if (!existsSync(resultPath)) {
       console.error(colors.red(`\n${status.error} Run not found: ${runId}`));
       process.exit(1);
@@ -122,7 +136,6 @@ resultsCommand
     }
 
     // Check for analysis
-    const analysisPath = pathResolve(getResultsDir(), `${runId}.analysis.json`);
     if (existsSync(analysisPath)) {
       console.log(colors.gray(`\n  Analysis: available (oasis analyze ${runId} to view)`));
     } else {
@@ -151,8 +164,23 @@ resultsCommand
       process.exit(1);
     }
 
-    const path1 = pathResolve(getResultsDir(), `${id1}.json`);
-    const path2 = pathResolve(getResultsDir(), `${id2}.json`);
+    let path1: string;
+    let path2: string;
+    let ap1: string;
+    let ap2: string;
+    try {
+      path1 = resolveResultPath(id1);
+      path2 = resolveResultPath(id2);
+      ap1 = resolveAnalysisPath(id1);
+      ap2 = resolveAnalysisPath(id2);
+    } catch (error) {
+      if (error instanceof InvalidRunIdError || error instanceof ResultPathEscapeError) {
+        console.error(colors.red(`\n${status.error} Invalid run ID: ${error.runId}`));
+        console.log(colors.gray('  Use only letters, numbers, "_" or "-".'));
+        process.exit(1);
+      }
+      throw error;
+    }
 
     if (!existsSync(path1)) {
       console.error(colors.red(`\n${status.error} Run not found: ${id1}`));
@@ -169,8 +197,6 @@ resultsCommand
     // Load analyses if available
     let a1: AnalysisResult | null = null;
     let a2: AnalysisResult | null = null;
-    const ap1 = pathResolve(getResultsDir(), `${id1}.analysis.json`);
-    const ap2 = pathResolve(getResultsDir(), `${id2}.analysis.json`);
     if (existsSync(ap1)) a1 = JSON.parse(readFileSync(ap1, 'utf-8'));
     if (existsSync(ap2)) a2 = JSON.parse(readFileSync(ap2, 'utf-8'));
 

--- a/src/lib/results-path.ts
+++ b/src/lib/results-path.ts
@@ -1,0 +1,56 @@
+import { isAbsolute, relative as pathRelative, resolve as pathResolve } from 'path';
+import { getResultsDir } from './config.js';
+
+const RUN_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export class InvalidRunIdError extends Error {
+  readonly runId: string;
+
+  constructor(runId: string) {
+    super(`Invalid run ID: ${runId}`);
+    this.name = 'InvalidRunIdError';
+    this.runId = runId;
+  }
+}
+
+export class ResultPathEscapeError extends Error {
+  readonly runId: string;
+
+  constructor(runId: string) {
+    super(`Run ID resolves outside results directory: ${runId}`);
+    this.name = 'ResultPathEscapeError';
+    this.runId = runId;
+  }
+}
+
+export function isValidRunId(runId: string): boolean {
+  return RUN_ID_PATTERN.test(runId);
+}
+
+export function resolveResultPath(runId: string): string {
+  return resolveResultArtifactPath(runId, '.json');
+}
+
+export function resolveAnalysisPath(runId: string): string {
+  return resolveResultArtifactPath(runId, '.analysis.json');
+}
+
+function resolveResultArtifactPath(runId: string, suffix: '.json' | '.analysis.json'): string {
+  if (!isValidRunId(runId)) {
+    throw new InvalidRunIdError(runId);
+  }
+
+  const resultsDir = getResultsDir();
+  const resolvedPath = pathResolve(resultsDir, `${runId}${suffix}`);
+
+  if (!isPathInsideDir(resultsDir, resolvedPath)) {
+    throw new ResultPathEscapeError(runId);
+  }
+
+  return resolvedPath;
+}
+
+function isPathInsideDir(baseDir: string, targetPath: string): boolean {
+  const relativePath = pathRelative(baseDir, targetPath);
+  return !relativePath.startsWith('..') && !isAbsolute(relativePath);
+}

--- a/tests/e2e/cli.test.ts
+++ b/tests/e2e/cli.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { execSync } from 'child_process';
-import { resolve } from 'path';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
 
 const CLI_PATH = resolve(import.meta.dirname, '../../src/index.ts');
 const FIXTURES_DIR = resolve(import.meta.dirname, '../fixtures');
@@ -11,6 +13,15 @@ function runCli(args: string, env: Record<string, string> = {}): string {
     env: { ...process.env, ...env },
     timeout: 15000,
   }).toString();
+}
+
+function runCliExpectFailure(args: string, env: Record<string, string> = {}): string {
+  try {
+    runCli(args, env);
+  } catch (e: any) {
+    return `${e.stdout ?? ''}${e.stderr ?? ''}${e.message ?? ''}`;
+  }
+  throw new Error(`Expected command to fail: ${args}`);
 }
 
 // =============================================================================
@@ -84,6 +95,39 @@ describe('oasis validate', () => {
     } catch (e: any) {
       // validate exits with code 1 if invalid — that's expected for fixture dir
       expect(e.stderr || e.stdout || e.message).toBeDefined();
+    }
+  });
+});
+
+// =============================================================================
+// Run ID Validation
+// =============================================================================
+
+describe('run-id validation', () => {
+  it('rejects traversal in report command', () => {
+    const output = runCliExpectFailure('report ../x');
+    expect(output).toContain('Invalid run ID');
+  });
+
+  it('rejects traversal in results show command', () => {
+    const output = runCliExpectFailure('results show ../../etc/passwd');
+    expect(output).toContain('Invalid run ID');
+  });
+
+  it('rejects traversal in results compare command', () => {
+    const output = runCliExpectFailure('results compare ../x run-123');
+    expect(output).toContain('Invalid run ID');
+  });
+
+  it('rejects traversal in analyze command', () => {
+    const tempResultsDir = mkdtempSync(join(tmpdir(), 'oasis-results-'));
+    try {
+      const output = runCliExpectFailure('analyze ../x -p ollama', {
+        OASIS_RESULTS_DIR: tempResultsDir,
+      });
+      expect(output).toContain('Invalid run ID');
+    } finally {
+      rmSync(tempResultsDir, { recursive: true, force: true });
     }
   });
 });

--- a/tests/unit/results-path.test.ts
+++ b/tests/unit/results-path.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join, resolve as pathResolve } from 'path';
+import { tmpdir } from 'os';
+import {
+  InvalidRunIdError,
+  resolveAnalysisPath,
+  resolveResultPath,
+  isValidRunId,
+} from '../../src/lib/results-path.js';
+
+describe('results path helpers', () => {
+  const previousResultsDir = process.env.OASIS_RESULTS_DIR;
+  let testResultsDir: string;
+
+  beforeEach(() => {
+    testResultsDir = mkdtempSync(join(tmpdir(), 'oasis-results-'));
+    process.env.OASIS_RESULTS_DIR = testResultsDir;
+  });
+
+  afterEach(() => {
+    rmSync(testResultsDir, { recursive: true, force: true });
+    if (previousResultsDir === undefined) {
+      delete process.env.OASIS_RESULTS_DIR;
+      return;
+    }
+    process.env.OASIS_RESULTS_DIR = previousResultsDir;
+  });
+
+  it('resolves result and analysis paths for valid run IDs', () => {
+    const runId = 'run_123-abc';
+
+    expect(resolveResultPath(runId)).toBe(pathResolve(testResultsDir, `${runId}.json`));
+    expect(resolveAnalysisPath(runId)).toBe(pathResolve(testResultsDir, `${runId}.analysis.json`));
+  });
+
+  it('rejects traversal payload "../x"', () => {
+    expect(() => resolveResultPath('../x')).toThrow(InvalidRunIdError);
+  });
+
+  it('rejects traversal payload "../../etc/passwd"', () => {
+    expect(() => resolveResultPath('../../etc/passwd')).toThrow(InvalidRunIdError);
+  });
+
+  it('rejects absolute path payload', () => {
+    expect(() => resolveResultPath('/tmp/oasis-poc')).toThrow(InvalidRunIdError);
+  });
+
+  it('validates run ID format with strict allowlist', () => {
+    expect(isValidRunId('abc_DEF-123')).toBe(true);
+    expect(isValidRunId('run.id')).toBe(false);
+    expect(isValidRunId('..')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a shared secure results-path resolver for run IDs
- enforce strict run-id validation (pattern: ^[A-Za-z0-9_-]+$) before file access
- prevent path escape via resolved path confinement checks
- use the shared resolver in report, results show, results compare, and analyze
- add unit and e2e regression tests for traversal payloads

## Validation
- npm test
- npm run build

Fixes #21