### PR TITLE
feat: back navigation in interactive wizard + ollama analyzer fix (#33)

### DIFF
--- a/src/interactive/run-flow.ts
+++ b/src/interactive/run-flow.ts
@@ -182,6 +182,10 @@ export async function runBenchmarkFlow(): Promise<void> {
         providerName = selected;
         provider = normalizeProvider(providerName);
         preset = PROVIDERS[provider] || PROVIDERS[providerName];
+        // Reset downstream state so stale credentials/model don't carry over
+        model = '';
+        resolvedApiKey = undefined;
+        resolvedApiUrl = undefined;
         step = Step.MODEL;
         break;
       }
@@ -233,8 +237,8 @@ export async function runBenchmarkFlow(): Promise<void> {
         }
 
         if (!model || model.trim().length === 0) {
-          console.log(colors.yellow(`\n  ${status.warning} No model specified. Try again.\n`));
-          break; // re-prompt MODEL step
+          step = Step.PROVIDER;
+          break;
         }
         model = model.trim();
 
@@ -305,8 +309,7 @@ export async function runBenchmarkFlow(): Promise<void> {
         });
 
         if (selected === '__back__') {
-          // Skip credentials, go back to model
-          step = Step.MODEL;
+          step = Step.CREDENTIALS;
           break;
         }
 

--- a/src/lib/analyzer.ts
+++ b/src/lib/analyzer.ts
@@ -20,7 +20,7 @@ import {
   fallbackOverallScore,
 } from './scoring.js';
 import { withRateLimitRetry } from './retry.js';
-import { isAnthropicProvider, resolveProvider } from './providers.js';
+import { isAnthropicProvider, resolveProvider, resolveProviderName } from './providers.js';
 
 // =============================================================================
 // Configuration
@@ -414,14 +414,21 @@ export interface AnalyzeOptions {
   challengeConfig?: ChallengeConfig;
 }
 
-export function resolveDefaultAnalyzerModel(provider: string, benchmarkModel?: string): string {
-  if (isAnthropicProvider(provider)) return DEFAULT_ANALYZER_MODEL;
-  // For local providers (ollama, custom), prefer the benchmark model
-  // since we can't know what the user has installed
-  if (benchmarkModel && (provider === 'ollama' || provider === 'custom')) {
-    return benchmarkModel;
+export function resolveDefaultAnalyzerModel(analyzerProvider: string, benchmarkResult: RunResult): string {
+  if (isAnthropicProvider(analyzerProvider)) return DEFAULT_ANALYZER_MODEL;
+
+  // If the analyzer runs on the same provider as the benchmark, use the benchmark model —
+  // it's the one we know is available (preset lists are hardcoded examples, not the user's actual models).
+  const preset = resolveProvider(analyzerProvider);
+
+  // If the analyzer runs on the same provider as the benchmark, use the benchmark model —
+  // it's the one we know is available (preset lists are hardcoded examples, not the user's actual models).
+  const benchmarkProvider = resolveProviderName(benchmarkResult.model);
+  if (benchmarkProvider === resolveProviderName(analyzerProvider)) {
+    return benchmarkResult.modelVersion || preset?.models[0] || DEFAULT_ANALYZER_MODEL;
   }
-  const preset = resolveProvider(provider);
+
+  // Different provider — try preset default, fall back to Claude
   return preset?.models[0] || DEFAULT_ANALYZER_MODEL;
 }
 
@@ -493,7 +500,7 @@ export async function analyzeRun(
   }
 
   // Resolve model — default per provider
-  const analyzerModel = options.analyzerModel || resolveDefaultAnalyzerModel(provider, result.modelVersion);
+  const analyzerModel = options.analyzerModel || resolveDefaultAnalyzerModel(provider, result);
 
   // Resolve base URL for OpenAI-compatible providers
   const baseUrl = options.baseUrl || (!useAnthropic

--- a/tests/unit/analyzer.test.ts
+++ b/tests/unit/analyzer.test.ts
@@ -1,6 +1,29 @@
 import { describe, it, expect } from 'vitest';
 import { calculateKSM, fallbackOverallScore } from '../../src/lib/scoring.js';
 import { resolveDefaultAnalyzerModel, DEFAULT_ANALYZER_MODEL } from '../../src/lib/analyzer.js';
+import type { RunResult } from '../../src/lib/types.js';
+
+function makeRunResult(model: string, modelVersion: string): RunResult {
+  return {
+    id: 'test-run',
+    model,
+    modelVersion,
+    challenge: 'test-challenge',
+    startTime: new Date(),
+    endTime: new Date(),
+    success: false,
+    flag: null,
+    totalTime: 10,
+    iterations: 1,
+    tokens: { input: 0, output: 0, total: 0 },
+    steps: [],
+    techniquesUsed: [],
+    tacticBreakdown: {},
+    methodologies: [],
+    toolsUsed: [],
+    methodologyBreakdown: {},
+  };
+}
 
 // =============================================================================
 // fallbackOverallScore
@@ -81,36 +104,58 @@ describe('fallbackOverallScore → calculateKSM pipeline', () => {
 // =============================================================================
 
 // =============================================================================
-// resolveDefaultAnalyzerModel — Ollama/custom benchmark-model fallback
+// resolveDefaultAnalyzerModel — provider-aware benchmark-model fallback
 // =============================================================================
 
 describe('resolveDefaultAnalyzerModel', () => {
   it('returns DEFAULT_ANALYZER_MODEL for anthropic provider', () => {
-    expect(resolveDefaultAnalyzerModel('anthropic')).toBe(DEFAULT_ANALYZER_MODEL);
+    const result = makeRunResult('ollama', 'qwen3:30b');
+    expect(resolveDefaultAnalyzerModel('anthropic', result)).toBe(DEFAULT_ANALYZER_MODEL);
   });
 
-  it('returns DEFAULT_ANALYZER_MODEL for anthropic even with benchmarkModel', () => {
-    expect(resolveDefaultAnalyzerModel('anthropic', 'qwen3:4b')).toBe(DEFAULT_ANALYZER_MODEL);
+  it('returns DEFAULT_ANALYZER_MODEL for claude alias', () => {
+    const result = makeRunResult('ollama', 'qwen3:30b');
+    expect(resolveDefaultAnalyzerModel('claude', result)).toBe(DEFAULT_ANALYZER_MODEL);
   });
 
-  it('returns benchmarkModel for ollama when provided', () => {
-    expect(resolveDefaultAnalyzerModel('ollama', 'qwen3:4b')).toBe('qwen3:4b');
+  it('returns benchmark model when providers match (ollama)', () => {
+    const result = makeRunResult('ollama', 'qwen3:30b');
+    expect(resolveDefaultAnalyzerModel('ollama', result)).toBe('qwen3:30b');
   });
 
-  it('returns benchmarkModel for custom provider when provided', () => {
-    expect(resolveDefaultAnalyzerModel('custom', 'my-local-model')).toBe('my-local-model');
+  it('returns benchmark model when providers match (openai)', () => {
+    const result = makeRunResult('openai', 'gpt-4o-mini');
+    expect(resolveDefaultAnalyzerModel('openai', result)).toBe('gpt-4o-mini');
   });
 
-  it('falls back to preset models[0] for ollama without benchmarkModel', () => {
-    // Without a benchmarkModel, ollama falls back to the preset list
-    const result = resolveDefaultAnalyzerModel('ollama');
-    expect(result).toBe('llama3.2'); // first model in PROVIDERS.ollama.models
+  it('returns benchmark model when providers match (xai)', () => {
+    const result = makeRunResult('xai', 'grok-3-latest');
+    expect(resolveDefaultAnalyzerModel('xai', result)).toBe('grok-3-latest');
   });
 
-  it('returns preset models[0] for cloud providers regardless of benchmarkModel', () => {
-    // Cloud providers (openai, xai, google) ignore benchmarkModel
-    const result = resolveDefaultAnalyzerModel('openai', 'some-model');
-    expect(result).not.toBe('some-model');
+  it('returns preset default when providers differ', () => {
+    const result = makeRunResult('ollama', 'qwen3:30b');
+    expect(resolveDefaultAnalyzerModel('openai', result)).toBe('gpt-4o');
+  });
+
+  it('returns DEFAULT_ANALYZER_MODEL for custom with different benchmark provider', () => {
+    const result = makeRunResult('openai', 'gpt-4o');
+    expect(resolveDefaultAnalyzerModel('custom', result)).toBe(DEFAULT_ANALYZER_MODEL);
+  });
+
+  it('returns benchmark model for custom when benchmark also used custom', () => {
+    const result = makeRunResult('custom', 'my-local-model');
+    expect(resolveDefaultAnalyzerModel('custom', result)).toBe('my-local-model');
+  });
+
+  it('handles provider aliases (grok -> xai)', () => {
+    const result = makeRunResult('xai', 'grok-3-latest');
+    expect(resolveDefaultAnalyzerModel('grok', result)).toBe('grok-3-latest');
+  });
+
+  it('handles provider aliases (gemini -> google)', () => {
+    const result = makeRunResult('google', 'gemini-2.0-flash');
+    expect(resolveDefaultAnalyzerModel('gemini', result)).toBe('gemini-2.0-flash');
   });
 });
 


### PR DESCRIPTION
## Summary

- **Back navigation**: Converts the linear `runBenchmarkFlow()` prompt sequence into a step-based state machine loop. Each step (source, challenge, provider, model, credentials, analysis, confirm) now includes a `← Back` option, matching the existing pattern in `results-flow.ts`. Users no longer need to Ctrl+C and restart when they pick the wrong option.
- **Ollama analyzer model fallback**: For local providers (ollama, custom), the analyzer now prefers the benchmark model since we can't know what models the user has installed locally.

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `npx vitest run` — all 311 tests pass
- [ ] Manual: run `oasis` interactively, navigate forward and back through all steps
- [ ] Verify `← Back` on source step returns to main menu
- [ ] Verify challenge list is cached when navigating back (no re-fetch)
- [ ] Verify credentials step is auto-skipped when going back from analysis
- [ ] Verify "No" on confirm step exits the flow