### PR TITLE
docs: add SDK bump entries to 0.1.3 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 - Interactive run wizard uses live model list with spinner + fallback to examples
 - Back-navigation wizard integrated with live model fetching
 - `executeAndRecordStep` helper now includes technique classification
+- Bumped `@anthropic-ai/sdk` ^0.71.2 → ^0.78.0
+- Bumped `openai` ^4.0.0 → ^6.25.0 (added type guard for v6 union type in runner)
 
 ## [0.1.2] - 2026-02-23
 


### PR DESCRIPTION
## Summary
- Adds missing changelog entries for the `@anthropic-ai/sdk` and `openai` SDK bumps from #40
- Documents the openai v4 → v6 major version change and type guard fix

One-liner — just filling a gap in the 0.1.3 release notes.