### PR TITLE
Fix Anthropic token undercount: include cached tokens

### DIFF
--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -380,7 +380,9 @@ async function runClaudeAgent(config: RunnerConfig): Promise<RunResult> {
         break;
       }
 
-      const stepInputTokens = response.usage.input_tokens;
+      const stepInputTokens = response.usage.input_tokens
+        + (response.usage.cache_creation_input_tokens ?? 0)
+        + (response.usage.cache_read_input_tokens ?? 0);
       const stepOutputTokens = response.usage.output_tokens;
       totalTokens.input += stepInputTokens;
       totalTokens.output += stepOutputTokens;


### PR DESCRIPTION
Anthropic's `input_tokens` doesn't mean what you think it means. It's not "total input tokens" — it's "tokens that weren't cached." The actual input total is `input_tokens + cache_creation_input_tokens + cache_read_input_tokens`, and we were just ignoring the last two.

Nobody's using `cache_control` in the runner today, so the numbers are correct by accident. But this is a benchmarking tool — "correct by accident" isn't a standard we should be comfortable with.

One-line fix in `runner.ts`. Sums all three fields with nullish coalescing so it's a no-op when caching isn't active and correct when it is.

Closes #44