### PR TITLE
fix: trimMessages() orphans tool messages, crashes OpenAI runs

### DIFF
--- a/src/lib/runner.ts
+++ b/src/lib/runner.ts
@@ -35,6 +35,11 @@ export function trimMessages<T extends { role: string }>(messages: T[]): T[] {
   while (start < tail.length && tail[start].role === messages[0].role) {
     start++;
   }
+  // Skip orphaned tool messages whose parent assistant+tool_calls was sliced off.
+  // OpenAI hard-rejects these with 400; other providers silently degrade.
+  while (start < tail.length && tail[start].role === 'tool') {
+    start++;
+  }
   return [messages[0], ...tail.slice(start)];
 }
 

--- a/tests/unit/runner.test.ts
+++ b/tests/unit/runner.test.ts
@@ -328,4 +328,51 @@ describe('trimMessages', () => {
     expect(result[0].role).toBe('system');
     expect(result.length).toBeLessThanOrEqual(MAX_CONTEXT_MESSAGES);
   });
+
+  it('skips orphaned tool messages at trim boundary', () => {
+    // Simulate a real agent conversation where trimming slices between
+    // an assistant+tool_calls message and its tool response.
+    // OpenAI rejects orphaned tool messages with 400.
+    const msgs: { role: string; content: string }[] = [
+      { role: 'user', content: 'system prompt' },
+    ];
+    // Fill with user/assistant pairs to push past the limit
+    for (let i = 1; i < MAX_CONTEXT_MESSAGES; i++) {
+      msgs.push({ role: i % 2 === 0 ? 'user' : 'assistant', content: `msg-${i}` });
+    }
+    // Now add a tool response that will land at the start of the tail
+    // after its parent assistant message gets sliced off
+    msgs.push({ role: 'tool', content: 'tool-response-orphaned' });
+    msgs.push({ role: 'tool', content: 'tool-response-orphaned-2' });
+    msgs.push({ role: 'assistant', content: 'next-reasoning' });
+    msgs.push({ role: 'user', content: 'latest' });
+
+    const result = trimMessages(msgs);
+    // The orphaned tool messages right after the anchor should be skipped
+    expect(result[1].role).not.toBe('tool');
+    // The non-orphaned messages (assistant, user) should follow the anchor
+    expect(result[1].role).toBe('assistant');
+  });
+
+  it('handles tool message right after anchor role collision', () => {
+    // Edge case: anchor is 'user', tail starts with 'user' (dropped by
+    // existing dedup), then 'tool' (should also be dropped)
+    const msgs: { role: string; content: string }[] = [
+      { role: 'user', content: 'anchor' },
+    ];
+    // Push past limit with alternating messages
+    for (let i = 1; i <= MAX_CONTEXT_MESSAGES + 2; i++) {
+      msgs.push({ role: i % 2 === 0 ? 'user' : 'assistant', content: `fill-${i}` });
+    }
+    // Manually inject a user+tool sequence at the expected tail boundary
+    // After slicing, tail[0] = 'user' (deduped), tail[1] = 'tool' (orphaned)
+    const tailStart = msgs.length - MAX_CONTEXT_MESSAGES + 1;
+    msgs[tailStart] = { role: 'user', content: 'collision' };
+    msgs[tailStart + 1] = { role: 'tool', content: 'orphaned-tool' };
+    msgs[tailStart + 2] = { role: 'assistant', content: 'recovery' };
+
+    const result = trimMessages(msgs);
+    expect(result[0].role).toBe('user');
+    expect(result[1].role).not.toBe('tool');
+  });
 });


### PR DESCRIPTION
## Summary

`trimMessages()` sliding window can slice between an `assistant` message (with `tool_calls`) and its `tool` response, orphaning the tool message. OpenAI hard-rejects this with a 400 — every other provider silently degrades by feeding the model a tool response with zero context for what was called.

Reproduced on `broken-auth-enum`:

| Model | Provider | Iterations | Result |
|-------|----------|-----------|--------|
| gpt-5.4 | OpenAI | 18/50 | **Crashed** — orphaned tool → 400 |
| claude-sonnet-4-5-20250929 | Anthropic | 50/50 | Survived, degraded context |
| grok-3-latest | xAI | 50/50 | Survived, degraded context |

The fix adds a second skip loop after the existing same-role dedup — any `tool` messages at the start of the trimmed tail get dropped since their parent `assistant` message was already sliced off.

Only manifests on challenges requiring ~20+ iterations. Easy challenges that complete in <15 iterations never trigger this.

## Test plan

- [x] New unit tests for orphaned tool messages at trim boundary
- [x] New unit test for tool messages after anchor role collision
- [x] Full suite passes (417/417)
- [x] Reproduced bug before fix (GPT-5.4 crashes at iteration 18)

Closes #69